### PR TITLE
Skip invalid index filenames for windows usage

### DIFF
--- a/ProcessUnreferencedFiles.php
+++ b/ProcessUnreferencedFiles.php
@@ -150,8 +150,8 @@ class ProcessUnreferencedFiles {
 		foreach ( $index_files as $filename => $key ) {
 			if ( file_exists( $filename ) ) {
 				$index_filename = $filename;
+				break;
 			}
-			break;
 		}
 
 		if ( is_null( $index_filename ) ) {


### PR DESCRIPTION
The fix is to ensure in windows, the following index files still get processed correctly, instead of just quit after 1st index file.

status_unreferenced_files is array (
  'processed' => 0,
  'current_index_file' => 
  array (
    'filename' => 'C:\\Bitnami\\wordpress-5.223\\apps\\wordpress\\htdocs/wp-content/uploads/sites/2\\2018/05\\.media-library-fix',
    'path' => 'C:\\Bitnami\\wordpress-5.223\\apps\\wordpress\\htdocs/wp-content/uploads/sites/2\\2018/05',
    'total_to_process' => 0,
    'next_to_process' => 0,
  ),
  'index_files' => 
  array (
    'C:\\Bitnami\\wordpress-5.223\\apps\\wordpress\\htdocs/wp-content/uploads/sites/2/2018/05\\.media-library-fix' => '*',
    'C:\\Bitnami\\wordpress-5.223\\apps\\wordpress\\htdocs/wp-content/uploads/sites/2\\2018/06\\.media-library-fix' => '*',
    'C:\\Bitnami\\wordpress-5.223\\apps\\wordpress\\htdocs/wp-content/uploads/sites/2/2018/06\\.media-library-fix' => '*',
  ),
)